### PR TITLE
Fix project setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
 monaco-typescript
-public/schema
+public/schema/*
+!public/schema/.gitkeep
 public/env.js

--- a/README.md
+++ b/README.md
@@ -12,23 +12,21 @@ Differences from https://www.typescriptlang.org/play:
 * Quicker sharing, URL updates as you type
 * Shorter sharing URLs
 
-## Install
+## Getting started
 
 ```
 npm install
-npm run fetch-schema
-npm run get-typescript
+npm run setup
+npm start
 ```
-
-## Start
-
-`npm start`
 
 ## Updating TypeScript
 
 Playground relies on [UNPKG](https://unpkg.com) to fetch `monaco-editor` (contains `typescript` through `monaco-typescript` package).
 
-In case if `monaco-editor` is not updated to the latest TypeScript, the latest version can be built with `npm run get-typescript` and served locally.
+In case if `monaco-editor` is not updated to the latest TypeScript, the latest version can be built with `npm run get-typescript latest` and served locally.
+
+In case you want to serve some specific version of TypeScript locally you should run `npm run get-typescript <version>`. For example, to serve TypeScript version 2.8.3 you should run `npm run get-typescript 2.8.3; npm start`
 
 ## Browser compatibility
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "serve ./public",
+    "setup": "npm run fetch-schema",
     "clean": "rm -rf monaco-typescript && rm -rf public/monaco-typescript",
     "get-typescript": "./scripts/get-typescript.sh",
     "deploy": "gh-pages --dist=public",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
     "clean": "rm -rf monaco-typescript && rm -rf public/monaco-typescript",
     "get-typescript": "./scripts/get-typescript.sh",
     "deploy": "gh-pages --dist=public",
-    "fetch-schema":
-      "curl http://json.schemastore.org/tsconfig > public/schema/tsconfig.json"
+    "fetch-schema": "curl http://json.schemastore.org/tsconfig > public/schema/tsconfig.json"
   },
   "keywords": [],
   "author": "",

--- a/scripts/get-typescript.sh
+++ b/scripts/get-typescript.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
-NPM_VERSION='latest'
-
+VERSION="$1"
 rm -rf monaco-typescript
 
 set -o nounset
@@ -12,8 +11,11 @@ git clone https://github.com/Microsoft/monaco-typescript
 pushd monaco-typescript
 
 # https://github.com/Microsoft/monaco-typescript#updating-typescript
-npm install typescript@${NPM_VERSION} --save-dev
-npm run import-typescript
+if [ ! -z "$VERSION" ]; then
+  npm install typescript@$VERSION --save-dev
+  npm run import-typescript
+fi
+
 npm install
 INSTALLED_VERSION=`node -p "require('typescript').version"`
 


### PR DESCRIPTION
- fix issue when schema folder absent (keeping it). It was not there when initially cloning repo and curl was failing.
- fix currently broken setup (when trying to setup TypeScript v2.9.1 and it breaks). 
- add ability to bootstrap any existing version of typescript
- Update docs to reflect changes