### PR TITLE
Adds checkbox for emitDecoratorMetadata

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -113,6 +113,7 @@ async function main() {
     skipLibCheck: false,
 
     experimentalDecorators: false,
+    emitDecoratorMetadata: false,
 
     target: monaco.languages.typescript.ScriptTarget.ES3,
     jsx: monaco.languages.typescript.JsxEmit.None,


### PR DESCRIPTION
Adds a checkbox for emitDecoratorMetadata, to see how various types are converted into `design:type` decorations.