### PR TITLE
Add canonical name for ts playground

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+typescript-play.js.org


### PR DESCRIPTION
This will create http://typescript-play.js.org as an alias to your gh pages.

Then make a PR here to enable the domain: https://github.com/js-org/js.org