### PR TITLE
auto-scroll options popup

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -172,3 +172,8 @@ header a {
   opacity: 0;
   transition: opacity 0.3s ease-in-out;
 }
+
+#settings-popup {
+    overflow-y: auto;
+    max-height: calc( 100vh - 5rem );
+}


### PR DESCRIPTION
Because I've noticed that I cannot scroll down to choose other TypeScript compiler option, I'm proposing a FIX. My first pain was when I tried to enable experimatlDecorators.

![image](https://user-images.githubusercontent.com/6409576/52462368-12e8f080-2b73-11e9-9fda-661a56f369c0.png)

This FIX allow us to scrool and choose other options...
![image](https://user-images.githubusercontent.com/6409576/52462449-6a875c00-2b73-11e9-92c6-a96ce81f5746.png)
