### PR TITLE
Prevent scroll bounce on macOS

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -3,6 +3,7 @@ body {
   padding: 0;
   width: 100vw;
   height: 100vh;
+  overflow: hidden;
   font: normal 16px/1.4em -apple-system, system-ui, BlinkMacSystemFont,
     "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans",
     "Helvetica Neue", Arial, sans-serif;


### PR DESCRIPTION
With the addition of `overflow: hidden` to the `body` tag, it's possible to prevent the scroll bounce on macOS. In my humble opinion it makes the website more solid.

Feel free to close this pull request if you're not interested in this addition.