### PR TITLE
Fixes issue #34

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -181,6 +181,15 @@ async function main() {
   </label>`;
   }
 
+  function createFile(compilerOptions) {
+    return monaco.Uri.file(
+      "input." +
+      (compilerOptions.jsx === monaco.languages.typescript.JsxEmit.None
+        ? "ts"
+        : "tsx")
+    )
+  }
+
   window.UI = {
     tooltips: {},
 
@@ -398,12 +407,7 @@ async function main() {
       State.inputModel = monaco.editor.createModel(
         inputCode,
         "typescript",
-        monaco.Uri.file(
-          "input." +
-          (compilerOptions.jsx === monaco.languages.typescript.JsxEmit.None
-            ? "ts"
-            : "tsx")
-        )
+        createFile(compilerOptions)
       );
       inputEditor.setModel(State.inputModel);
 
@@ -444,12 +448,7 @@ console.log(message);
   State.inputModel = monaco.editor.createModel(
     UI.getInitialCode(),
     "typescript",
-    monaco.Uri.file(
-      "input." + 
-      (compilerOptions.jsx === monaco.languages.typescript.JsxEmit.None
-        ? "ts"
-        : "tsx")
-    ),
+    createFile(compilerOptions)
   );
 
   State.outputModel = monaco.editor.createModel(

--- a/public/main.js
+++ b/public/main.js
@@ -444,7 +444,12 @@ console.log(message);
   State.inputModel = monaco.editor.createModel(
     UI.getInitialCode(),
     "typescript",
-    monaco.Uri.file("input.ts"),
+    monaco.Uri.file(
+      "input" + 
+      (compilerOptions.jsx === monaco.languages.typescript.JsxEmit.None
+        ? "ts"
+        : "tsx")
+    ),
   );
 
   State.outputModel = monaco.editor.createModel(

--- a/public/main.js
+++ b/public/main.js
@@ -493,7 +493,7 @@ console.log(message);
   });
 
   updateOutput();
-  State.inputModel.onDidChangeContent(() => {
+  inputEditor.onDidChangeModelContent(() => {
     updateOutput();
   });
   UI.shouldUpdateHash = true;

--- a/public/main.js
+++ b/public/main.js
@@ -445,7 +445,7 @@ console.log(message);
     UI.getInitialCode(),
     "typescript",
     monaco.Uri.file(
-      "input" + 
+      "input." + 
       (compilerOptions.jsx === monaco.languages.typescript.JsxEmit.None
         ? "ts"
         : "tsx")

--- a/public/main.js
+++ b/public/main.js
@@ -157,6 +157,8 @@ async function main() {
     outputModel: null,
   };
 
+  let inputEditor, outputEditor;
+
   function createSelect(obj, globalPath, title, compilerOption) {
     return `<label class="select">
     <span class="select-label">${title}</span>
@@ -391,6 +393,20 @@ async function main() {
         compilerOptions,
       );
 
+      let inputCode = inputEditor.getValue();
+      State.inputModel.dispose();
+      State.inputModel = monaco.editor.createModel(
+        inputCode,
+        "typescript",
+        monaco.Uri.file(
+          "input." +
+          (compilerOptions.jsx === monaco.languages.typescript.JsxEmit.None
+            ? "ts"
+            : "tsx")
+        )
+      );
+      inputEditor.setModel(State.inputModel);
+
       UI.refreshOutput();
 
       UI.renderSettings();
@@ -428,7 +444,7 @@ console.log(message);
   State.inputModel = monaco.editor.createModel(
     UI.getInitialCode(),
     "typescript",
-    monaco.Uri.file("input.tsx"),
+    monaco.Uri.file("input.ts"),
   );
 
   State.outputModel = monaco.editor.createModel(
@@ -437,12 +453,12 @@ console.log(message);
     monaco.Uri.file("output.js"),
   );
 
-  const inputEditor = monaco.editor.create(
+  inputEditor = monaco.editor.create(
     document.getElementById("input"),
     Object.assign({ model: State.inputModel }, sharedEditorOptions),
   );
 
-  const outputEditor = monaco.editor.create(
+  outputEditor = monaco.editor.create(
     document.getElementById("output"),
     Object.assign({ model: State.outputModel }, sharedEditorOptions),
   );


### PR DESCRIPTION
1. The issue was caused because the input file was with model URI as `.tsx` even when JSX is set "None".
2. It made sense to put the model changing (according to `compilerOptions.jsx`) code to [`updateCompileOptions`][1] function.
3. Also that needed the `inputEditor` variable so I [hoisted it to the top][2]. To make things consistent I also hoisted `outputEditor`. The hoisting is not done in an awkward position, the variables are kept with other similar globals like `State`, `compilerOptions`, etc.
4. The default `compilerOptions.jsx` is ["None"][3]. So [I made the initial model URI also `.ts`][4]

I also hosted [typescript-play-pr-35.surge.sh](https://typescript-play-pr-35.surge.sh) that has this PR. [Here][5] is the buggy version from original website and [here][6] is the fixed version having the same input code.

(This was my first issue, my first pull request and also kinda the first time I'm actually using git to contribute. So please excuse my mistakes if any 😅)

[1]: https://github.com/devanshj/typescript-play/blob/master/public/main.js#L396-L408
[2]: https://github.com/devanshj/typescript-play/blob/master/public/main.js#L160
[3]: https://github.com/devanshj/typescript-play/blob/master/public/main.js#L119
[4]: https://github.com/devanshj/typescript-play/blob/master/public/main.js#L447
[5]:https://typescript-play.js.org/#code/MYewdgzgLgBAlgEwKZinKBPGBeGAeAFQD4AKADwC4YCBKHImMgbiA
[6]:https://typescript-play-pr-35.surge.sh/#code/MYewdgzgLgBAlgEwKZinKBPGBeGAeAFQD4AKADwC4YCBKHImMgbiA