### PR TITLE
Fix various things to get typescript 3.5.1 working

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ npm start
 Playground relies on [UNPKG](https://unpkg.com) to fetch `monaco-editor` (contains `typescript` through [`monaco-typescript`](https://github.com/Microsoft/monaco-typescript) package).
 
 In case if `monaco-editor` is not updated to the latest TypeScript, the latest version can be built with `npm run get-typescript latest` and served locally.
+If you run into errors, the latest monaco version may be incompatible with the latest typescript version,
+in which case you'll need to update monaco-typescript upstream, or apply a patch locally (see the `# Patches` section in [get-typescript.sh](scripts/get-typescript.sh).
 
 In case you want to serve some specific version of TypeScript locally you should run `npm run get-typescript <version>`. For example, to serve TypeScript version 2.8.3 you should run `npm run get-typescript 2.8.3; npm start`
 

--- a/patch/3.5.1.patch
+++ b/patch/3.5.1.patch
@@ -1,0 +1,24 @@
+diff --git a/src/tsconfig.esm.json b/src/tsconfig.esm.json
+index b95798a..6efc6a0 100644
+--- a/src/tsconfig.esm.json
++++ b/src/tsconfig.esm.json
+@@ -8,6 +8,7 @@
+       "dom",
+       "es5",
+       "es2015.collection",
++      "es2015.iterable",
+       "es2015.promise"
+     ]
+   },
+diff --git a/src/tsconfig.json b/src/tsconfig.json
+index f4ff52f..778087c 100644
+--- a/src/tsconfig.json
++++ b/src/tsconfig.json
+@@ -8,6 +8,7 @@
+       "dom",
+       "es5",
+       "es2015.collection",
++      "es2015.iterable",
+       "es2015.promise"
+     ]
+   },

--- a/scripts/get-typescript.sh
+++ b/scripts/get-typescript.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 VERSION="$1"
+MONACO_VERSION="${2:-latest}"
 rm -rf monaco-typescript
 
 set -o nounset
@@ -10,26 +11,38 @@ git clone https://github.com/Microsoft/monaco-typescript
 
 pushd monaco-typescript
 
-# https://github.com/Microsoft/monaco-typescript#updating-typescript
 if [ ! -z "$VERSION" ]; then
+	# https://github.com/Microsoft/monaco-typescript#updating-typescript
   npm install typescript@$VERSION --save-dev
-
-  if [ $VERSION = "2.9.1" ]; then
-    git apply ../patch/2.9.1.patch
-  fi
-  if [ $VERSION = "3.2.1" ]; then
-    git apply ../patch/3.2.1.patch
-  fi
-
-  npm run prepublishOnly
+	# Continued below after applying patches
 fi
 
 npm install
 INSTALLED_VERSION=`node -p "require('typescript').version"`
+
+if [ ! -z "$VERSION" ]; then
+	# Patches
+  if [ $INSTALLED_VERSION = "2.9.1" ]; then
+    git apply ../patch/2.9.1.patch
+  fi
+  if [ $INSTALLED_VERSION = "3.2.1" ]; then
+    git apply ../patch/3.2.1.patch
+  fi
+  if [ $INSTALLED_VERSION = "3.5.1" ]; then
+    git apply ../patch/3.5.1.patch
+  fi
+
+  npm run import-typescript
+  npm run prepublishOnly
+fi
 
 popd
 
 mkdir -vp ./public/monaco-typescript/${INSTALLED_VERSION}
 cp -vr ./monaco-typescript/release/min/ ./public/monaco-typescript/${INSTALLED_VERSION}
 
-echo "window.localTSVersion = { '$INSTALLED_VERSION': { monaco: '0.15.6', lib: '/monaco-typescript/$INSTALLED_VERSION' } }" > public/env.js
+echo "window.localTSVersion = { '$INSTALLED_VERSION': { monaco: '$MONACO_VERSION', lib: '/monaco-typescript/$INSTALLED_VERSION' } }" > public/env.js
+
+echo
+echo "Added typescript version '$INSTALLED_VERSION' with monaco version '$MONACO_VERSION'. Make sure they are compatible!"
+echo "(You can customize them via arguments to this script.)"


### PR DESCRIPTION
- Added a patch for monaco-typescript
- get-typescript.sh fixes:
  - remove hard-coded monaco version that was old and incompatible
  - use 'latest' for monaco by default, allow for override
  - add required call to `npm run import-typescript`
    (as described at https://github.com/Microsoft/monaco-typescript#updating-typescript)
  - allow patches to work on the resolved version when specifying "latest"

With these fixes, `npm run get-typescript latest` now results in a working product with
typescript 3.5.1 🎉